### PR TITLE
[Merged by Bors] - Run all tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         toolchain: ${{ matrix.rust }}
         override: true
     - name: Run unit tests
-      run:  cargo test --lib --all-features
+      run:  cargo test --all-features
 
   check_fmt:
     name: check cargo fmt


### PR DESCRIPTION
We previously only ran unit tests. This enabled integration tests as well.