### PR TITLE
[Merged by Bors] - Do lhs expression ordering at deserialization step

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,11 +165,9 @@ name = "fluvio-jolt"
 version = "0.2.0"
 dependencies = [
  "criterion",
- "indexmap",
  "serde",
  "serde_json",
  "thiserror",
- "xxhash-rust",
 ]
 
 [[package]]
@@ -210,7 +208,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
- "serde",
 ]
 
 [[package]]
@@ -627,9 +624,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "xxhash-rust"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "735a71d46c4d68d71d4b24d03fdc2b98e38cea81730595801db779c04fe80d70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,6 @@ crate-type = ['cdylib', 'rlib']
 serde = { version = "1", features = ["derive"] }
 serde_json = {version = "1", features = ["preserve_order"]}
 thiserror = "1"
-indexmap = { version = "1", features = ["serde"] }
-xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/dsl/ast.rs
+++ b/src/dsl/ast.rs
@@ -7,7 +7,7 @@ pub enum Lhs {
     Amp(usize, usize),
     At(usize, Box<Rhs>),
     Square(String),
-    /// Bunch of star expression separated by pipes
+    /// Bunch of star expressions separated by pipes
     Pipes(Vec<Stars>),
     Literal(String),
 }

--- a/src/dsl/deserialize.rs
+++ b/src/dsl/deserialize.rs
@@ -1,21 +1,33 @@
-use std::hash::Hash;
+use std::collections::HashSet;
 use std::fmt;
 
 use serde::de::{self, Visitor};
-use serde::{de::Deserializer, Deserialize};
+use serde::{
+    de::{Error as _, Deserializer},
+    Deserialize,
+};
 
-use super::ast::{Rhs, Lhs};
+use super::ast::{Rhs, Lhs, Stars};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LhsWithHash {
-    pub lhs: Lhs,
-    pub input: String,
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum InfallibleLhs {
+    DollarSign(usize, usize),
+    At(usize, Box<Rhs>),
+    Square(String),
 }
 
-impl Hash for LhsWithHash {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.input.hash(state)
-    }
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Object {
+    infallible: Vec<(InfallibleLhs, Rhs)>,
+    literal: Vec<(String, REntry)>,
+    amp: Vec<((usize, usize), REntry)>,
+    pipes: Vec<(Vec<Stars>, REntry)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum REntry {
+    Obj(Box<Object>),
+    Rhs(Rhs),
 }
 
 struct RhsVisitor;
@@ -35,29 +47,96 @@ impl<'de> Visitor<'de> for RhsVisitor {
     }
 }
 
+impl<'de> Deserialize<'de> for Rhs {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(RhsVisitor)
+    }
+}
+
+struct ObjectVisitor;
+
+impl<'de> Visitor<'de> for ObjectVisitor {
+    type Value = Object;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("map")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::MapAccess<'de>,
+        A::Error: de::Error,
+    {
+        let mut obj = Object::default();
+
+        let mut key_set = HashSet::new();
+
+        while let Some(lhs) = map.next_key()? {
+            if !key_set.insert(lhs) {
+                return Err(A::Error::custom("duplicate lhs"));
+            }
+
+            let lhs = LhsVisitor.visit_str(lhs)?;
+
+            match lhs {
+                Lhs::DollarSign(idx0, idx1) => {
+                    obj.infallible
+                        .push((InfallibleLhs::DollarSign(idx0, idx1), map.next_value()?));
+                }
+                Lhs::Amp(idx0, idx1) => {
+                    obj.amp.push(((idx0, idx1), map.next_value()?));
+                }
+                Lhs::At(idx, rhs) => {
+                    obj.infallible
+                        .push((InfallibleLhs::At(idx, rhs), map.next_value()?));
+                }
+                Lhs::Square(lit) => {
+                    obj.infallible
+                        .push((InfallibleLhs::Square(lit), map.next_value()?));
+                }
+                Lhs::Pipes(pipes) => {
+                    obj.pipes.push((pipes, map.next_value()?));
+                }
+                Lhs::Literal(lit) => {
+                    obj.literal.push((lit, map.next_value()?));
+                }
+            }
+        }
+
+        Ok(obj)
+    }
+}
+
+impl<'de> Deserialize<'de> for Object {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(ObjectVisitor)
+    }
+}
+
 struct LhsVisitor;
 
 impl<'de> Visitor<'de> for LhsVisitor {
-    type Value = LhsWithHash;
+    type Value = Lhs;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("left hand side expression")
+        formatter.write_str("Lhs expression")
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
     where
         E: de::Error,
     {
-        let lhs = Lhs::parse(value)
-            .map_err(|e| E::custom(format!("failed to parse: {value}.error={e}")))?;
-        Ok(LhsWithHash {
-            lhs,
-            input: value.to_owned(),
-        })
+        Lhs::parse(value).map_err(|e| E::custom(format!("failed to parse: {value}.error={e}")))
     }
 }
 
-impl<'de> Deserialize<'de> for LhsWithHash {
+impl<'de> Deserialize<'de> for Lhs {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -66,11 +145,28 @@ impl<'de> Deserialize<'de> for LhsWithHash {
     }
 }
 
-impl<'de> Deserialize<'de> for Rhs {
+struct REntryVisitor;
+
+impl<'de> Visitor<'de> for REntryVisitor {
+    type Value = REntry;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("Right hand side entry")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        RhsVisitor.visit_str(value).map(REntry::Rhs)
+    }
+}
+
+impl<'de> Deserialize<'de> for REntry {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_str(RhsVisitor)
+        deserializer.deserialize_str(REntryVisitor)
     }
 }

--- a/src/dsl/mod.rs
+++ b/src/dsl/mod.rs
@@ -10,4 +10,4 @@ mod chars;
 
 pub use error::ParseError;
 pub use ast::{Rhs, Lhs, RhsEntry, IndexOp, RhsPart};
-pub use deserialize::LhsWithHash;
+pub use deserialize::{InfallibleLhs, Object, REntry};

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,8 +25,10 @@ pub enum Error {
     KeyNotFound(String),
     #[error("Expression didn't evaluate to a string.")]
     EvalString,
-    #[error("Empty path while executing shift.")]
+    #[error("Empty path while executing shift. THIS SHOULD NEVER HAPPEN.")]
     ShiftEmptyPath,
+    #[error("Path is not empty after executing shift. THIS SHOULD NEVER HAPPEN.")]
+    ShiftPathNotEmpty,
 }
 
 pub type Result<T> = StdResult<T, Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,8 @@ pub enum Error {
     KeyNotFound(String),
     #[error("Expression didn't evaluate to a string.")]
     EvalString,
+    #[error("Empty path while executing shift.")]
+    ShiftEmptyPath,
 }
 
 pub type Result<T> = StdResult<T, Error>;


### PR DESCRIPTION
Previously we deserialized objects using `IndexMap` which didn't differentiate between different kind of expressions so we had to order them when running the `shift` operation.

This PR updates deserialization to do the ordering and lhs-rhs match (if lhs is infallible, rhs has to be an expr or an array) check when deserializing.

This removes complexity from runtime and moves it to deserialization time.

I also removed some not easy to validate unwraps from `shift` implementation but left the obvious ones in.

I'll add unit tests for `shift` in next PR.