### PR TITLE
[Merged by Bors] - fix(workflow): remove package-name input when calling

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -52,7 +52,6 @@ jobs:
     needs: build
     uses: infinyon/fluvio/.github/workflows/smartmodule-publish.yml@master
     with:
-      package-name: jolt
       branch: ${{ github.event.inputs.branch }}
       fail-fast: false
       target_prod: ${{ github.event.inputs.target_prod }}


### PR DESCRIPTION
Sorry about this, I missed initially. Not sure how to test without running the workflow.