### PR TITLE
[Merged by Bors] - fix(workflow): setup wasm target before running smdk build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,6 +35,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.branch }}
+      - name: Setup wasm32-unknown-unknown target 
+        run: rustup target add wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
         with:
           cache-targets: "false"


### PR DESCRIPTION
Setup wasm target before building. [Seems like it should work this way](https://github.com/rustwasm/wasm-bindgen/blob/0853bb7fa7727b0cc5a93974449970ce4bbf1970/.github/workflows/main.yml#L48C14-L48C14)