### PR TITLE
[Merged by Bors] - fix(workflow): fix bloolean input handling in smartmodule publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,7 +55,7 @@ jobs:
     uses: infinyon/fluvio/.github/workflows/smartmodule-publish.yml@master
     with:
       fail-fast: false
-      target_prod: ${{ github.event.inputs.target_prod }}
+      target_prod: ${{ inputs.target_prod }}
       artifact-name: smartmodule-artifact
       ipkg-file-name: jolt-${{ github.event.inputs.smartmodule-version }}.ipkg
     secrets: inherit


### PR DESCRIPTION
The action runner treats boolean input as string when accessed from the `event` object.

related link: https://github.com/orgs/community/discussions/29796